### PR TITLE
Use plus icon for restore button in CompletedCard

### DIFF
--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -260,16 +260,16 @@ function CompletedCard({ task, onRestore }) {
         <div className="flex-1 text-sm md:text-base">{task.text}</div>
         <button
           onClick={onRestore}
-          className="px-3 md:px-4 py-1 rounded-xl border text-sm md:text-base transition active:scale-95"
+          className="px-3 md:px-4 py-1 rounded-xl border text-lg font-bold transition active:scale-95"
           style={{
             color: COLORS.neonCyan,
             background: COLORS.panel,
             borderColor: COLORS.cardBorder,
           }}
           aria-label="Restore task"
-          title="Move back to Tasks"
+          title="Restore task"
         >
-          Restore
+          ＋
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace "Restore" text with a ＋ icon in CompletedCard
- Ensure accessibility by keeping aria-label and tooltip for restore action

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af22f57a30832ab0cd20b40a444e72