### PR TITLE
Ensure task completion button bypasses dnd-kit drag handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+react-app/node_modules/
+react-app/dist/

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -254,7 +254,10 @@ function TaskCardBase({ task, onComplete, dragging }) {
             e.stopPropagation();
             onComplete();
           }}
-          onMouseDown={(e) => e.stopPropagation()}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
           className="px-3 md:px-4 py-1 rounded-xl border text-lg font-bold transition active:scale-95"
           style={{
             color: COLORS.neonLime,


### PR DESCRIPTION
## Summary
- prevent dnd-kit from intercepting the task completion button by stopping propagation and preventing default on mousedown
- ignore node_modules and dist build outputs

## Testing
- `npm --prefix react-app run build`
- `node - <<'NODE'
let nextId = 1;
const makeTask = (text) => ({ id: `t-${nextId++}`, text });
let tasks = [makeTask("A")];
let completed = [];
let activeTab = 'tasks';
function handleComplete(taskId) {
  const idx = tasks.findIndex((t) => t.id === taskId);
  if (idx === -1) return;
  const t = tasks[idx];
  completed = [makeTask(t.text), ...completed];
  tasks = [...tasks.slice(0, idx), ...tasks.slice(idx + 1)];
  activeTab = 'completed';
}
handleComplete(tasks[0].id);
console.log('activeTab:', activeTab);
console.log('tasks:', tasks);
console.log('completed:', completed);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68af27cc7bac832aa08d39a121c6b2c0