### PR TITLE
Switch to completed tab when task is completed

### DIFF
--- a/python-tk/cyberpunk_tasks.py
+++ b/python-tk/cyberpunk_tasks.py
@@ -209,6 +209,7 @@ class TaskCard:
         self.shadow.master = self.parent_frame
         self.shadow.pack(fill="x", padx=CARD_PADX, pady=CARD_PADY)
         self.app.completed.append(self)
+        self.app.notebook.select(self.app.tab_completed)
         self.app.refresh_scrollregions()
 
         # Enable button to allow restoring the task


### PR DESCRIPTION
## Summary
- show completed tab after marking task complete

## Testing
- `python -m py_compile python-tk/cyberpunk_tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68af29c27654832a9669d8c42f6944f3