### PR TITLE
Preserve task IDs on completion

### DIFF
--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -83,13 +83,10 @@ export default function App() {
   }
 
   function handleComplete(taskId) {
-    setTasks((prev) => {
-      const idx = prev.findIndex((t) => t.id === taskId);
-      if (idx === -1) return prev;
-      const t = prev[idx];
-      setCompleted((c) => [makeTask(t.text), ...c]);
-      return [...prev.slice(0, idx), ...prev.slice(idx + 1)];
-    });
+    const task = tasks.find((t) => t.id === taskId);
+    if (!task) return;
+    setTasks((prev) => prev.filter((t) => t.id !== taskId));
+    setCompleted((c) => [task, ...c]);
     setActiveTab("completed");
   }
 


### PR DESCRIPTION
## Summary
- Avoid generating a new ID when completing a task
- Remove completed tasks from active list and prepend to completed list using original ID

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af2ddb2874832a9877b69c3d6b6582