### PR TITLE
Use pack in_ to move task cards between areas

### DIFF
--- a/python-tk/cyberpunk_tasks.py
+++ b/python-tk/cyberpunk_tasks.py
@@ -206,8 +206,12 @@ class TaskCard:
 
         # Add to completed area
         self.parent_frame = self.app.completed_area.inner
-        self.shadow.master = self.parent_frame
-        self.shadow.pack(fill="x", padx=CARD_PADX, pady=CARD_PADY)
+        self.shadow.pack(
+            fill="x",
+            padx=CARD_PADX,
+            pady=CARD_PADY,
+            in_=self.app.completed_area.inner,
+        )
         self.app.completed.append(self)
         self.app.notebook.select(self.app.tab_completed)
         self.app.refresh_scrollregions()
@@ -244,7 +248,12 @@ class TaskCard:
 
         # Move back to active area
         self.parent_frame = self.app.active_area.inner
-        self.shadow.master = self.parent_frame
+        self.shadow.pack(
+            fill="x",
+            padx=CARD_PADX,
+            pady=CARD_PADY,
+            in_=self.app.active_area.inner,
+        )
 
         # Restore button to complete action
         self.complete_btn.configure(text="-", command=self.complete, state="normal")


### PR DESCRIPTION
## Summary
- Fix task completion by packing card shadow into the Completed tab using the `in_` parameter
- Restore tasks back to Active tab using `in_` so cards move cleanly between tabs

## Testing
- `python -m py_compile python-tk/cyberpunk_tasks.py`
- `python python-tk/cyberpunk_tasks.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68af4708dd98832aa9ce84aca5f7a993