### PR TITLE
Fix Tk task card parent reassignment when moving

### DIFF
--- a/python-tk/cyberpunk_tasks.py
+++ b/python-tk/cyberpunk_tasks.py
@@ -205,13 +205,10 @@ class TaskCard:
         self.complete_btn.configure(state="disabled")
 
         # Add to completed area
+        self.shadow.pack_forget()
+        self.shadow.master = self.app.completed_area.inner
+        self.shadow.pack(fill="x", padx=CARD_PADX, pady=CARD_PADY)
         self.parent_frame = self.app.completed_area.inner
-        self.shadow.pack(
-            fill="x",
-            padx=CARD_PADX,
-            pady=CARD_PADY,
-            in_=self.app.completed_area.inner,
-        )
         self.app.completed.append(self)
         self.app.notebook.select(self.app.tab_completed)
         self.app.refresh_scrollregions()
@@ -247,13 +244,10 @@ class TaskCard:
             w.bind("<ButtonRelease-1>", self.on_drag_release)
 
         # Move back to active area
+        self.shadow.pack_forget()
+        self.shadow.master = self.app.active_area.inner
+        self.shadow.pack(fill="x", padx=CARD_PADX, pady=CARD_PADY)
         self.parent_frame = self.app.active_area.inner
-        self.shadow.pack(
-            fill="x",
-            padx=CARD_PADX,
-            pady=CARD_PADY,
-            in_=self.app.active_area.inner,
-        )
 
         # Restore button to complete action
         self.complete_btn.configure(text="-", command=self.complete, state="normal")


### PR DESCRIPTION
## Summary
- Fix TaskCard.complete and restore to reassign parent widget before repacking
- Ensure parent_frame attribute tracks current container

## Testing
- `python -m py_compile python-tk/cyberpunk_tasks.py`
- `python - <<'PY'
import tkinter as tk
root = tk.Tk()
root.destroy()
PY` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68af48cb4de8832aa60c4d5277dcfb4e